### PR TITLE
Mapping context

### DIFF
--- a/assertions/src/main/java/io/doov/assertions/ResultAssert.java
+++ b/assertions/src/main/java/io/doov/assertions/ResultAssert.java
@@ -75,6 +75,7 @@ public class ResultAssert extends AbstractAssert<ResultAssert, Result> {
      * Locale control to make tests independent from system locale
      *
      * @param message the message
+     * @param locale locale
      * @return self
      */
     public ResultAssert hasFailureCause(String message, Locale locale) {

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,11 @@ subprojects {
         useJUnitPlatform()
     }
 
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
+        options.compilerArgs << '-proc:none'
+    }
+
     task javadocJar(type: Jar) {
         classifier = 'javadoc'
         from javadoc

--- a/core/src/main/java/io/doov/core/dsl/DOOV.java
+++ b/core/src/main/java/io/doov/core/dsl/DOOV.java
@@ -20,18 +20,15 @@ import static io.doov.core.dsl.meta.LeafMetadata.trueMetadata;
 import static java.util.Arrays.asList;
 
 import java.util.*;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.function.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import io.doov.core.dsl.field.types.NumericFieldInfo;
 import io.doov.core.dsl.impl.*;
+import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.mapping.MappingRegistry;
-import io.doov.core.dsl.lang.MappingRule;
-import io.doov.core.dsl.lang.StepCondition;
-import io.doov.core.dsl.lang.StepWhen;
 import io.doov.core.dsl.mapping.*;
 
 /**
@@ -242,6 +239,27 @@ public class DOOV {
      */
     public static <I> StaticStepMap<I> map(I value) {
         return new StaticStepMap<>(() -> value);
+    }
+
+    /**
+     * Start defining a value mapping with value null
+     *
+     * @param <I> value type
+     * @return value map step
+     */
+    public static <I> StaticStepMap<I> mapNull() {
+        return new StaticStepMap<>(() -> null);
+    }
+
+    /**
+     * Start defining a context-aware value mapping
+     *
+     * @param valueFunction context dependent value function
+     * @param <I> value type
+     * @return value map step
+     */
+    public static <I> ContextawareStepMap<I> map(BiFunction<DslModel, Context, I> valueFunction) {
+        return new ContextawareStepMap<>(valueFunction);
     }
 
     /**

--- a/core/src/main/java/io/doov/core/dsl/impl/AbstractStepCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/AbstractStepCondition.java
@@ -17,7 +17,6 @@ import static io.doov.core.dsl.meta.ast.AstVisitorUtils.astToString;
 import java.util.Locale;
 import java.util.function.BiPredicate;
 
-import io.doov.core.FieldId;
 import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.lang.Context;
 import io.doov.core.dsl.lang.StepCondition;
@@ -41,7 +40,7 @@ abstract class AbstractStepCondition implements StepCondition {
     @Override
     public BiPredicate<DslModel, Context> predicate() {
         return (model, context) -> {
-            final boolean test = predicate.test(new Interceptor(model, context), context);
+            final boolean test = predicate.test(new ModelInterceptor(model, context), context);
             if (test) {
                 metadata.incTrueEval();
                 context.addEvalTrue(metadata);
@@ -51,29 +50,6 @@ abstract class AbstractStepCondition implements StepCondition {
             }
             return test;
         };
-    }
-
-    private static final class Interceptor implements DslModel {
-        private final DslModel model;
-        private final Context context;
-
-        Interceptor(DslModel model, Context context) {
-            this.model = model;
-            this.context = context;
-        }
-
-        @Override
-        public <T> T get(FieldId id) {
-            final T value = model.get(id);
-            context.addEvalValue(id, value);
-            return value;
-        }
-
-        @Override
-        public <T> void set(FieldId fieldId, T value) {
-            model.set(fieldId, value);
-            // TODO context
-        }
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/impl/DefaultContext.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/DefaultContext.java
@@ -69,7 +69,12 @@ public class DefaultContext implements Context {
     public void addEvalValue(FieldId id, Object value) {
         values.put(id, value);
     }
-    
+
+    @Override
+    public void addSetValue(FieldId id, Object value) {
+        values.put(id, value);
+    }
+
     @Override
     public Object getEvalValue(FieldId id) {
         return values.get(id);

--- a/core/src/main/java/io/doov/core/dsl/impl/DefaultResult.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/DefaultResult.java
@@ -20,9 +20,9 @@ import io.doov.core.dsl.lang.Result;
 public class DefaultResult implements Result {
 
     private final boolean validated;
-    private final DefaultContext context;
+    private final Context context;
 
-    protected DefaultResult(boolean validated, DefaultContext context) {
+    protected DefaultResult(boolean validated, Context context) {
         this.validated = validated;
         this.context = context;
     }

--- a/core/src/main/java/io/doov/core/dsl/impl/DefaultValidationRule.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/DefaultValidationRule.java
@@ -50,7 +50,11 @@ public class DefaultValidationRule implements ValidationRule {
 
     @Override
     public Result executeOn(DslModel model) {
-        final DefaultContext context = new DefaultContext(shortCircuit, stepWhen.stepCondition().getMetadata());
+        return executeOn(model, new DefaultContext(shortCircuit, stepWhen.stepCondition().getMetadata()));
+    }
+
+    @Override
+    public Result executeOn(DslModel model, Context context) {
         boolean valid = stepWhen.stepCondition().predicate().test(model, context);
         return new DefaultResult(valid, context);
     }

--- a/core/src/main/java/io/doov/core/dsl/impl/ModelInterceptor.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/ModelInterceptor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) by Courtanet, All Rights Reserved.
+ */
+package io.doov.core.dsl.impl;
+
+import io.doov.core.FieldId;
+import io.doov.core.dsl.DslModel;
+import io.doov.core.dsl.lang.Context;
+
+public final class ModelInterceptor implements DslModel {
+    private final DslModel model;
+    private final Context context;
+
+    public ModelInterceptor(DslModel model, Context context) {
+        this.model = model;
+        this.context = context;
+    }
+
+    @Override
+    public <T> T get(FieldId id) {
+        final T value = model.get(id);
+        context.addEvalValue(id, value);
+        return value;
+    }
+
+    @Override
+    public <T> void set(FieldId fieldId, T value) {
+        model.set(fieldId, value);
+        context.addSetValue(fieldId, value);
+    }
+}

--- a/core/src/main/java/io/doov/core/dsl/lang/BiTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/BiTypeConverter.java
@@ -16,6 +16,7 @@ public interface BiTypeConverter<I, J, O> extends SyntaxTree {
      * Convert the given fields in with type {@link O} {@link J}, the model to the value in type {@link O}
      *
      * @param fieldModel field model
+     * @param context context
      * @param in 1st in field
      * @param in2 2nd in field
      * @return output value

--- a/core/src/main/java/io/doov/core/dsl/lang/BiTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/BiTypeConverter.java
@@ -1,7 +1,7 @@
 package io.doov.core.dsl.lang;
 
-import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.meta.SyntaxTree;
 
 /**
@@ -20,5 +20,5 @@ public interface BiTypeConverter<I, J, O> extends SyntaxTree {
      * @param in2 2nd in field
      * @return output value
      */
-    O convert(FieldModel fieldModel, DslField<I> in, DslField<J> in2);
+    O convert(DslModel fieldModel, Context context, DslField<I> in, DslField<J> in2);
 }

--- a/core/src/main/java/io/doov/core/dsl/lang/Context.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/Context.java
@@ -62,6 +62,14 @@ public interface Context {
     void addEvalValue(FieldId id, Object value);
 
     /**
+     * Adds the set value for the given field id.
+     *
+     * @param id    the id
+     * @param value the value
+     */
+    void addSetValue(FieldId id, Object value);
+
+    /**
      * Return the evaluation value for this field id.
      *
      * @param id the id

--- a/core/src/main/java/io/doov/core/dsl/lang/MappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/MappingRule.java
@@ -31,6 +31,7 @@ public interface MappingRule extends SyntaxTree {
      *
      * @param inModel in model
      * @param outModel out model
+     * @param context context
      */
     void executeOn(FieldModel inModel, FieldModel outModel, Context context);
 

--- a/core/src/main/java/io/doov/core/dsl/lang/MappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/MappingRule.java
@@ -27,6 +27,14 @@ public interface MappingRule extends SyntaxTree {
     void executeOn(FieldModel inModel, FieldModel outModel);
 
     /**
+     * Execute the mapping rule on in/out models with given context
+     *
+     * @param inModel in model
+     * @param outModel out model
+     */
+    void executeOn(FieldModel inModel, FieldModel outModel, Context context);
+
+    /**
      * Stream over mapping rules contained in this rule Default implementation returns a stream of itself.
      *
      * @return mapping rule stream

--- a/core/src/main/java/io/doov/core/dsl/lang/MappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/MappingRule.java
@@ -23,17 +23,20 @@ public interface MappingRule extends SyntaxTree {
      *
      * @param inModel in model
      * @param outModel out model
+     * @return context
      */
-    void executeOn(FieldModel inModel, FieldModel outModel);
+    Context executeOn(FieldModel inModel, FieldModel outModel);
 
     /**
      * Execute the mapping rule on in/out models with given context
      *
      * @param inModel in model
      * @param outModel out model
+     * @param <C> context type
      * @param context context
+     * @return context
      */
-    void executeOn(FieldModel inModel, FieldModel outModel, Context context);
+    <C extends Context> C executeOn(FieldModel inModel, FieldModel outModel, C context);
 
     /**
      * Stream over mapping rules contained in this rule Default implementation returns a stream of itself.

--- a/core/src/main/java/io/doov/core/dsl/lang/NaryTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/NaryTypeConverter.java
@@ -14,6 +14,7 @@ public interface NaryTypeConverter<O> extends SyntaxTree {
      * Convert the given in fields in the model to the value in type {@link O}
      *
      * @param fieldModel in model
+     * @param context context
      * @param ins in fields
      * @return out value
      */

--- a/core/src/main/java/io/doov/core/dsl/lang/NaryTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/NaryTypeConverter.java
@@ -1,7 +1,7 @@
 package io.doov.core.dsl.lang;
 
-import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.meta.SyntaxTree;
 
 /**
@@ -17,5 +17,5 @@ public interface NaryTypeConverter<O> extends SyntaxTree {
      * @param ins in fields
      * @return out value
      */
-    O convert(FieldModel fieldModel, DslField... ins);
+    O convert(DslModel fieldModel, Context context, DslField... ins);
 }

--- a/core/src/main/java/io/doov/core/dsl/lang/StaticTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/StaticTypeConverter.java
@@ -18,6 +18,6 @@ public interface StaticTypeConverter<I, O> extends SyntaxTree {
      * @param input input
      * @return output
      */
-    O convert(I input);
+    O convert(Context context, I input);
 
 }

--- a/core/src/main/java/io/doov/core/dsl/lang/StaticTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/StaticTypeConverter.java
@@ -15,6 +15,7 @@ public interface StaticTypeConverter<I, O> extends SyntaxTree {
     /**
      * Return the converted value
      *
+     * @param context context
      * @param input input
      * @return output
      */

--- a/core/src/main/java/io/doov/core/dsl/lang/TriFunction.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/TriFunction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) by Courtanet, All Rights Reserved.
+ */
+package io.doov.core.dsl.lang;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * This is the three-arity specialization of {@link Function}.
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <U> the type of the second argument to the function
+ * @param <V> the type of the third argument to the function
+ * @param <R> the type of the result of the function
+ */
+public interface TriFunction<T, U, V, R> {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t the first function argument
+     * @param u the second function argument
+     * @param v the third function argument
+     * @return the function result
+     */
+    R apply(T t, U u, V v);
+
+    /**
+     * Returns a composed function that first applies this function
+     *
+     * @param <W>   the type of output of the {@code after} function, and of the
+     *              composed function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <W> TriFunction<T, U, V, W> andThen(Function<? super R, ? extends W> after) {
+        Objects.requireNonNull(after);
+        return (T t, U u, V v) -> after.apply(apply(t, u, v));
+    }
+
+}

--- a/core/src/main/java/io/doov/core/dsl/lang/TypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/TypeConverter.java
@@ -1,7 +1,7 @@
 package io.doov.core.dsl.lang;
 
-import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.meta.SyntaxTree;
 
 /**
@@ -18,6 +18,6 @@ public interface TypeConverter<I, O> extends SyntaxTree {
      * @param in in field
      * @return converted output value
      */
-    O convert(FieldModel fieldModel, DslField<I> in);
+    O convert(DslModel fieldModel, Context context, DslField<I> in);
 
 }

--- a/core/src/main/java/io/doov/core/dsl/lang/TypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/TypeConverter.java
@@ -15,6 +15,7 @@ public interface TypeConverter<I, O> extends SyntaxTree {
      * Convert the given field in with type {@link O}, the model to the value in type {@link O}
      *
      * @param fieldModel field model
+     * @param context context
      * @param in in field
      * @return converted output value
      */

--- a/core/src/main/java/io/doov/core/dsl/lang/ValidationRule.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/ValidationRule.java
@@ -39,6 +39,15 @@ public interface ValidationRule extends SyntaxTree {
     Result executeOn(DslModel model);
 
     /**
+     * Executes the validation rule on the given model.
+     *
+     * @param model the model
+     * @param context custom context
+     * @return the result
+     */
+    Result executeOn(DslModel model, Context context);
+
+    /**
      * Registers this rule on the given registry.
      *
      * @param registry the registry

--- a/core/src/main/java/io/doov/core/dsl/mapping/BiMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/BiMappingRule.java
@@ -8,8 +8,9 @@ import java.util.Locale;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
-import io.doov.core.dsl.lang.BiTypeConverter;
-import io.doov.core.dsl.lang.MappingRule;
+import io.doov.core.dsl.impl.DefaultContext;
+import io.doov.core.dsl.impl.ModelInterceptor;
+import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.MappingMetadata;
 import io.doov.core.dsl.meta.MetadataVisitor;
 
@@ -45,8 +46,15 @@ public class BiMappingRule<I, J, O> implements MappingRule {
     }
 
     @Override
+    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+        ModelInterceptor in = new ModelInterceptor(inModel, context);
+        ModelInterceptor out = new ModelInterceptor(outModel, context);
+        out.set(outFieldInfo.id(), typeConverter.convert(in, context, inFieldInfo, in2FieldInfo));
+    }
+
+    @Override
     public void executeOn(FieldModel inModel, FieldModel outModel) {
-        outModel.set(outFieldInfo.id(), typeConverter.convert(inModel, inFieldInfo, in2FieldInfo));
+        this.executeOn(inModel, outModel, new DefaultContext(this.metadata));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/BiMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/BiMappingRule.java
@@ -46,15 +46,16 @@ public class BiMappingRule<I, J, O> implements MappingRule {
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+    public <C extends Context> C executeOn(FieldModel inModel, FieldModel outModel, C context) {
         ModelInterceptor in = new ModelInterceptor(inModel, context);
         ModelInterceptor out = new ModelInterceptor(outModel, context);
         out.set(outFieldInfo.id(), typeConverter.convert(in, context, inFieldInfo, in2FieldInfo));
+        return context;
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel) {
-        this.executeOn(inModel, outModel, new DefaultContext(this.metadata));
+    public Context executeOn(FieldModel inModel, FieldModel outModel) {
+        return executeOn(inModel, outModel, new DefaultContext(this.metadata));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/ContextawareMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/ContextawareMappingRule.java
@@ -34,19 +34,14 @@ public class ContextawareMappingRule<I, O> implements MappingRule {
     }
 
     @Override
-    public void accept(MetadataVisitor visitor, int depth) {
-        metadata.accept(visitor, depth);
-        converter.accept(visitor, depth);
-    }
-
-    @Override
-    public String readable(Locale locale) {
-        return astToString(this, locale);
-    }
-
-    @Override
     public boolean validate(FieldModel inModel, FieldModel outModel) {
         return outModel.getFieldInfos().stream().anyMatch(f -> f.id().equals(outFieldInfo.id()));
+    }
+
+    @Override
+    public Context executeOn(FieldModel inModel, FieldModel outModel) {
+        return this.executeOn(inModel, outModel, new DefaultContext(metadata));
+
     }
 
     @Override
@@ -58,8 +53,13 @@ public class ContextawareMappingRule<I, O> implements MappingRule {
     }
 
     @Override
-    public Context executeOn(FieldModel inModel, FieldModel outModel) {
-        return this.executeOn(inModel, outModel, new DefaultContext(metadata));
+    public void accept(MetadataVisitor visitor, int depth) {
+        metadata.accept(visitor, depth);
+        converter.accept(visitor, depth);
+    }
+    @Override
+    public String readable(Locale locale) {
+        return astToString(this, locale);
     }
 
 }

--- a/core/src/main/java/io/doov/core/dsl/mapping/ContextawareMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/ContextawareMappingRule.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) by Courtanet, All Rights Reserved.
+ */
+package io.doov.core.dsl.mapping;
+
+import static io.doov.core.dsl.meta.MappingMetadata.mapping;
+import static io.doov.core.dsl.meta.ast.AstVisitorUtils.astToString;
+
+import java.util.Locale;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import io.doov.core.FieldModel;
+import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
+import io.doov.core.dsl.impl.DefaultContext;
+import io.doov.core.dsl.impl.ModelInterceptor;
+import io.doov.core.dsl.lang.*;
+import io.doov.core.dsl.meta.MappingMetadata;
+import io.doov.core.dsl.meta.MetadataVisitor;
+
+public class ContextawareMappingRule<I, O> implements MappingRule {
+
+    private final MappingMetadata metadata;
+    private final BiFunction<DslModel, Context, I> valueFunction;
+    private DslField<O> outFieldInfo;
+    private StaticTypeConverter<I, O> converter;
+
+    public ContextawareMappingRule(BiFunction<DslModel, Context, I> valueFunction, DslField<O> outFieldInfo,
+            StaticTypeConverter<I, O> converter) {
+        this.valueFunction = valueFunction;
+        this.metadata = mapping(valueFunction, outFieldInfo);
+        this.outFieldInfo = outFieldInfo;
+        this.converter = converter;
+    }
+
+    @Override
+    public void accept(MetadataVisitor visitor, int depth) {
+        metadata.accept(visitor, depth);
+        converter.accept(visitor, depth);
+    }
+
+    @Override
+    public String readable(Locale locale) {
+        return astToString(this, locale);
+    }
+
+    @Override
+    public boolean validate(FieldModel inModel, FieldModel outModel) {
+        return outModel.getFieldInfos().stream().anyMatch(f -> f.id().equals(outFieldInfo.id()));
+    }
+
+    @Override
+    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+        ModelInterceptor out = new ModelInterceptor(outModel, context);
+        ModelInterceptor in = new ModelInterceptor(inModel, context);
+        out.set(outFieldInfo.id(), converter.convert(context, valueFunction.apply(in, context)));
+    }
+
+    @Override
+    public void executeOn(FieldModel inModel, FieldModel outModel) {
+        this.executeOn(inModel, outModel, new DefaultContext(metadata));
+    }
+
+}

--- a/core/src/main/java/io/doov/core/dsl/mapping/ContextawareMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/ContextawareMappingRule.java
@@ -8,7 +8,6 @@ import static io.doov.core.dsl.meta.ast.AstVisitorUtils.astToString;
 
 import java.util.Locale;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
@@ -51,15 +50,16 @@ public class ContextawareMappingRule<I, O> implements MappingRule {
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+    public <C extends Context> C executeOn(FieldModel inModel, FieldModel outModel, C context) {
         ModelInterceptor out = new ModelInterceptor(outModel, context);
         ModelInterceptor in = new ModelInterceptor(inModel, context);
         out.set(outFieldInfo.id(), converter.convert(context, valueFunction.apply(in, context)));
+        return context;
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel) {
-        this.executeOn(inModel, outModel, new DefaultContext(metadata));
+    public Context executeOn(FieldModel inModel, FieldModel outModel) {
+        return this.executeOn(inModel, outModel, new DefaultContext(metadata));
     }
 
 }

--- a/core/src/main/java/io/doov/core/dsl/mapping/ContextawareStepMap.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/ContextawareStepMap.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) by Courtanet, All Rights Reserved.
+ */
+package io.doov.core.dsl.mapping;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
+import io.doov.core.dsl.lang.*;
+
+public class ContextawareStepMap<I> {
+
+    private final BiFunction<DslModel, Context, I> valueFunction;
+
+    public ContextawareStepMap(BiFunction<DslModel, Context, I> valueFunction) {
+        this.valueFunction = valueFunction;
+    }
+
+    /**
+     * Return the static mapping rule
+     *
+     * @param outFieldInfo out field info
+     * @return the static mapping rule
+     */
+    public ContextawareMappingRule<I, I> to(DslField<I> outFieldInfo) {
+        return new ContextawareMappingRule<>(valueFunction, outFieldInfo, DefaultStaticTypeConverter.identity());
+    }
+
+    /**
+     * Return the step mapping
+     *
+     * @param typeConverter static type converter
+     * @param <O>           out type
+     * @return the step mapping
+     */
+    public <O> ContextawareStepMapping<I, O> using(StaticTypeConverter<I, O> typeConverter) {
+        return new ContextawareStepMapping<>(valueFunction, typeConverter);
+    }
+}

--- a/core/src/main/java/io/doov/core/dsl/mapping/ContextawareStepMapping.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/ContextawareStepMapping.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) by Courtanet, All Rights Reserved.
+ */
+package io.doov.core.dsl.mapping;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
+import io.doov.core.dsl.lang.Context;
+import io.doov.core.dsl.lang.StaticTypeConverter;
+
+public class ContextawareStepMapping<I, O> {
+
+    private final BiFunction<DslModel, Context, I> valueFunction;
+    private final StaticTypeConverter<I, O> typeConverter;
+
+    ContextawareStepMapping(BiFunction<DslModel, Context, I> valueFunction, StaticTypeConverter<I, O> typeConverter) {
+        this.valueFunction = valueFunction;
+        this.typeConverter = typeConverter;
+    }
+
+    /**
+     * Return the mapping rule
+     *
+     * @param outFieldInfo out field
+     * @return static mapping rule
+     */
+    public ContextawareMappingRule<I, O> to(DslField<O> outFieldInfo) {
+        return new ContextawareMappingRule<>(valueFunction, outFieldInfo, typeConverter);
+    }
+}

--- a/core/src/main/java/io/doov/core/dsl/mapping/DefaultBiTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/DefaultBiTypeConverter.java
@@ -6,9 +6,10 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.lang.BiTypeConverter;
+import io.doov.core.dsl.lang.Context;
 import io.doov.core.dsl.meta.ConverterMetadata;
 import io.doov.core.dsl.meta.MetadataVisitor;
 
@@ -27,7 +28,7 @@ public class DefaultBiTypeConverter<I, J, O> implements BiTypeConverter<I, J, O>
     }
 
     @Override
-    public O convert(FieldModel fieldModel, DslField<I> in, DslField<J> in2) {
+    public O convert(DslModel fieldModel, Context context, DslField<I> in, DslField<J> in2) {
         return converter.apply(
                 Optional.ofNullable(fieldModel.get(in.id())),
                 Optional.ofNullable(fieldModel.get(in2.id())));

--- a/core/src/main/java/io/doov/core/dsl/mapping/DefaultBiTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/DefaultBiTypeConverter.java
@@ -8,28 +8,32 @@ import java.util.function.BiFunction;
 
 import io.doov.core.dsl.DslField;
 import io.doov.core.dsl.DslModel;
-import io.doov.core.dsl.lang.BiTypeConverter;
-import io.doov.core.dsl.lang.Context;
+import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.ConverterMetadata;
 import io.doov.core.dsl.meta.MetadataVisitor;
 
 public class DefaultBiTypeConverter<I, J, O> implements BiTypeConverter<I, J, O> {
 
-    private BiFunction<Optional<I>, Optional<J>, O> converter;
+    private TriFunction<Context, Optional<I>, Optional<J>, O> function;
     private ConverterMetadata metadata;
 
-    public DefaultBiTypeConverter(BiFunction<Optional<I>, Optional<J>, O> converter, String description) {
+    public DefaultBiTypeConverter(TriFunction<Context, Optional<I>, Optional<J>, O> function,
+            ConverterMetadata metadata) {
+        this.function = function;
+        this.metadata = metadata;
+    }
+
+    public DefaultBiTypeConverter(TriFunction<Context, Optional<I>, Optional<J>, O> converter, String description) {
         this(converter, ConverterMetadata.metadata(description));
     }
 
-    public DefaultBiTypeConverter(BiFunction<Optional<I>, Optional<J>, O> converter, ConverterMetadata metadata) {
-        this.converter = converter;
-        this.metadata = metadata;
+    public DefaultBiTypeConverter(BiFunction<Optional<I>, Optional<J>, O> function, String description) {
+        this((c, i, j) -> function.apply(i, j), description);
     }
 
     @Override
     public O convert(DslModel fieldModel, Context context, DslField<I> in, DslField<J> in2) {
-        return converter.apply(
+        return function.apply(context,
                 Optional.ofNullable(fieldModel.get(in.id())),
                 Optional.ofNullable(fieldModel.get(in2.id())));
     }

--- a/core/src/main/java/io/doov/core/dsl/mapping/DefaultConditionalMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/DefaultConditionalMappingRule.java
@@ -8,6 +8,7 @@ import static io.doov.core.dsl.meta.ast.AstVisitorUtils.astToString;
 import java.util.Locale;
 
 import io.doov.core.FieldModel;
+import io.doov.core.dsl.impl.DefaultContext;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.MappingMetadata;
 import io.doov.core.dsl.meta.MetadataVisitor;
@@ -53,12 +54,17 @@ public class DefaultConditionalMappingRule implements ConditionalMappingRule {
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel) {
-        if (validationRule.executeOn(inModel).isTrue()) {
-            mappingRules.executeOn(inModel, outModel);
+    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+        if (validationRule.executeOn(inModel, context).isTrue()) {
+            mappingRules.executeOn(inModel, outModel, context);
         } else if (!elseMappingRules.isEmpty()) {
-            elseMappingRules.executeOn(inModel, outModel);
+            elseMappingRules.executeOn(inModel, outModel, context);
         }
+    }
+
+    @Override
+    public void executeOn(FieldModel inModel, FieldModel outModel) {
+        this.executeOn(inModel, outModel, new DefaultContext(mappings(then)));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/DefaultConditionalMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/DefaultConditionalMappingRule.java
@@ -54,17 +54,18 @@ public class DefaultConditionalMappingRule implements ConditionalMappingRule {
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+    public <C extends Context> C executeOn(FieldModel inModel, FieldModel outModel, C context) {
         if (validationRule.executeOn(inModel, context).isTrue()) {
             mappingRules.executeOn(inModel, outModel, context);
         } else if (!elseMappingRules.isEmpty()) {
             elseMappingRules.executeOn(inModel, outModel, context);
         }
+        return context;
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel) {
-        this.executeOn(inModel, outModel, new DefaultContext(mappings(then)));
+    public Context executeOn(FieldModel inModel, FieldModel outModel) {
+        return this.executeOn(inModel, outModel, new DefaultContext(mappings(then)));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/DefaultNaryTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/DefaultNaryTypeConverter.java
@@ -7,29 +7,31 @@ import java.util.function.BiFunction;
 
 import io.doov.core.dsl.DslField;
 import io.doov.core.dsl.DslModel;
-import io.doov.core.dsl.lang.Context;
-import io.doov.core.dsl.lang.NaryTypeConverter;
+import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.ConverterMetadata;
 import io.doov.core.dsl.meta.MetadataVisitor;
 
 public class DefaultNaryTypeConverter<O> implements NaryTypeConverter<O> {
 
+    private final TriFunction<DslModel, Context, List<DslField>, O> function;
     private final ConverterMetadata metadata;
-    private BiFunction<DslModel, List<DslField>, O> function;
 
-    public DefaultNaryTypeConverter(BiFunction<DslModel, List<DslField>, O> function, String description) {
-        this(function, ConverterMetadata.metadata(description));
-    }
-
-    public DefaultNaryTypeConverter(BiFunction<DslModel, List<DslField>, O> function, ConverterMetadata metadata) {
+    public DefaultNaryTypeConverter(TriFunction<DslModel, Context, List<DslField>, O> function, ConverterMetadata metadata) {
         this.function = function;
         this.metadata = metadata;
     }
 
+    public DefaultNaryTypeConverter(TriFunction<DslModel, Context, List<DslField>, O> function, String description) {
+        this(function, ConverterMetadata.metadata(description));
+    }
+
+    public DefaultNaryTypeConverter(BiFunction<DslModel, List<DslField>, O> function, String description) {
+        this((m, c, f) -> function.apply(m, f), description);
+    }
+
     @Override
     public O convert(DslModel dslModel, Context context, DslField... fieldInfos) {
-        // TODO hack
-        return function.apply(dslModel, Arrays.asList(fieldInfos));
+        return function.apply(dslModel, context, Arrays.asList(fieldInfos));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/DefaultNaryTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/DefaultNaryTypeConverter.java
@@ -5,8 +5,9 @@ import static io.doov.core.dsl.meta.ast.AstVisitorUtils.astToString;
 import java.util.*;
 import java.util.function.BiFunction;
 
-import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
+import io.doov.core.dsl.lang.Context;
 import io.doov.core.dsl.lang.NaryTypeConverter;
 import io.doov.core.dsl.meta.ConverterMetadata;
 import io.doov.core.dsl.meta.MetadataVisitor;
@@ -14,21 +15,21 @@ import io.doov.core.dsl.meta.MetadataVisitor;
 public class DefaultNaryTypeConverter<O> implements NaryTypeConverter<O> {
 
     private final ConverterMetadata metadata;
-    private BiFunction<FieldModel, List<DslField>, O> function;
+    private BiFunction<DslModel, List<DslField>, O> function;
 
-    public DefaultNaryTypeConverter(BiFunction<FieldModel, List<DslField>, O> function, String description) {
+    public DefaultNaryTypeConverter(BiFunction<DslModel, List<DslField>, O> function, String description) {
         this(function, ConverterMetadata.metadata(description));
     }
 
-    public DefaultNaryTypeConverter(BiFunction<FieldModel, List<DslField>, O> function, ConverterMetadata metadata) {
+    public DefaultNaryTypeConverter(BiFunction<DslModel, List<DslField>, O> function, ConverterMetadata metadata) {
         this.function = function;
         this.metadata = metadata;
     }
 
     @Override
-    public O convert(FieldModel fieldModel, DslField... fieldInfos) {
+    public O convert(DslModel dslModel, Context context, DslField... fieldInfos) {
         // TODO hack
-        return function.apply(fieldModel, Arrays.asList(fieldInfos));
+        return function.apply(dslModel, Arrays.asList(fieldInfos));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/DefaultStaticTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/DefaultStaticTypeConverter.java
@@ -6,17 +6,19 @@ package io.doov.core.dsl.mapping;
 import static io.doov.core.dsl.meta.ast.AstVisitorUtils.astToString;
 
 import java.util.Locale;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
+import io.doov.core.dsl.lang.Context;
 import io.doov.core.dsl.lang.StaticTypeConverter;
-import io.doov.core.dsl.meta.*;
+import io.doov.core.dsl.meta.ConverterMetadata;
+import io.doov.core.dsl.meta.MetadataVisitor;
 
 public class DefaultStaticTypeConverter<I, O> implements StaticTypeConverter<I, O> {
 
     private static final DefaultStaticTypeConverter<?, ?> IDENTITY =
-            new DefaultStaticTypeConverter<>(Function.identity(), ConverterMetadata.identity());
+            new DefaultStaticTypeConverter<>(((context, o) -> o), ConverterMetadata.identity());
 
-    private final Function<I, O> function;
+    private final BiFunction<Context, I, O> function;
     private final ConverterMetadata metadata;
 
     @SuppressWarnings("unchecked")
@@ -24,18 +26,18 @@ public class DefaultStaticTypeConverter<I, O> implements StaticTypeConverter<I, 
         return (StaticTypeConverter<I, I>) IDENTITY;
     }
 
-    public DefaultStaticTypeConverter(Function<I, O> function, String description) {
+    public DefaultStaticTypeConverter(BiFunction<Context, I, O> function, String description) {
         this(function, ConverterMetadata.metadata(description));
     }
 
-    public DefaultStaticTypeConverter(Function<I, O> function, ConverterMetadata metadata) {
+    public DefaultStaticTypeConverter(BiFunction<Context, I, O> function, ConverterMetadata metadata) {
         this.function = function;
         this.metadata = metadata;
     }
 
     @Override
-    public O convert(I input) {
-        return function.apply(input);
+    public O convert(Context context, I input) {
+        return function.apply(context, input);
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/DefaultStaticTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/DefaultStaticTypeConverter.java
@@ -7,6 +7,7 @@ import static io.doov.core.dsl.meta.ast.AstVisitorUtils.astToString;
 
 import java.util.Locale;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import io.doov.core.dsl.lang.Context;
 import io.doov.core.dsl.lang.StaticTypeConverter;
@@ -16,7 +17,7 @@ import io.doov.core.dsl.meta.MetadataVisitor;
 public class DefaultStaticTypeConverter<I, O> implements StaticTypeConverter<I, O> {
 
     private static final DefaultStaticTypeConverter<?, ?> IDENTITY =
-            new DefaultStaticTypeConverter<>(((context, o) -> o), ConverterMetadata.identity());
+            new DefaultStaticTypeConverter<>(((context, i) -> i), ConverterMetadata.identity());
 
     private final BiFunction<Context, I, O> function;
     private final ConverterMetadata metadata;
@@ -26,13 +27,17 @@ public class DefaultStaticTypeConverter<I, O> implements StaticTypeConverter<I, 
         return (StaticTypeConverter<I, I>) IDENTITY;
     }
 
+    public DefaultStaticTypeConverter(BiFunction<Context, I, O> function, ConverterMetadata metadata) {
+        this.function = function;
+        this.metadata = metadata;
+    }
+
     public DefaultStaticTypeConverter(BiFunction<Context, I, O> function, String description) {
         this(function, ConverterMetadata.metadata(description));
     }
 
-    public DefaultStaticTypeConverter(BiFunction<Context, I, O> function, ConverterMetadata metadata) {
-        this.function = function;
-        this.metadata = metadata;
+    public DefaultStaticTypeConverter(Function<I, O> function, String description) {
+        this((context, i) -> function.apply(i), description);
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/DefaultTypeConverter.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/DefaultTypeConverter.java
@@ -6,8 +6,9 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
-import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
+import io.doov.core.dsl.lang.Context;
 import io.doov.core.dsl.lang.TypeConverter;
 import io.doov.core.dsl.meta.ConverterMetadata;
 import io.doov.core.dsl.meta.MetadataVisitor;
@@ -35,7 +36,7 @@ public class DefaultTypeConverter<I, O> implements TypeConverter<I, O> {
     }
 
     @Override
-    public O convert(FieldModel fieldModel, DslField<I> in) {
+    public O convert(DslModel fieldModel, Context context, DslField<I> in) {
         return converter.apply(Optional.ofNullable(fieldModel.get(in.id())));
     }
 

--- a/core/src/main/java/io/doov/core/dsl/mapping/MappingRegistry.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/MappingRegistry.java
@@ -10,6 +10,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.doov.core.FieldModel;
+import io.doov.core.dsl.impl.DefaultContext;
+import io.doov.core.dsl.lang.Context;
 import io.doov.core.dsl.lang.MappingRule;
 import io.doov.core.dsl.meta.MappingMetadata;
 import io.doov.core.dsl.meta.MappingOperator;
@@ -50,8 +52,21 @@ public class MappingRegistry implements MappingRule {
      * @param outModel out model
      */
     public void validateAndExecute(FieldModel inModel, FieldModel outModel) {
+        DefaultContext context = new DefaultContext(REGISTRY_METADATA);
         mappingRules.stream().filter(m -> m.validate(inModel, outModel))
-                .forEach(m -> m.executeOn(inModel, outModel));
+                .forEach(m -> m.executeOn(inModel, outModel, context));
+    }
+
+    /**
+     * Validate and execute rules in this registry with contained order on given models
+     *
+     * @param inModel  in model
+     * @param outModel out model
+     * @param context context
+     */
+    public void validateAndExecute(FieldModel inModel, FieldModel outModel, Context context) {
+        mappingRules.stream().filter(m -> m.validate(inModel, outModel))
+                .forEach(m -> m.executeOn(inModel, outModel, context));
     }
 
     /**
@@ -67,10 +82,13 @@ public class MappingRegistry implements MappingRule {
     }
 
     @Override
+    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+        mappingRules.forEach(rule -> rule.executeOn(inModel, outModel, context));
+    }
+
+    @Override
     public void executeOn(FieldModel inModel, FieldModel outModel) {
-        for (MappingRule rule : mappingRules) {
-            rule.executeOn(inModel, outModel);
-        }
+        this.executeOn(inModel, outModel, new DefaultContext(REGISTRY_METADATA));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/MappingRegistry.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/MappingRegistry.java
@@ -13,9 +13,7 @@ import io.doov.core.FieldModel;
 import io.doov.core.dsl.impl.DefaultContext;
 import io.doov.core.dsl.lang.Context;
 import io.doov.core.dsl.lang.MappingRule;
-import io.doov.core.dsl.meta.MappingMetadata;
-import io.doov.core.dsl.meta.MappingOperator;
-import io.doov.core.dsl.meta.MetadataVisitor;
+import io.doov.core.dsl.meta.*;
 
 /**
  * Immutable, ordered, composable container for {@link MappingRule}s
@@ -50,11 +48,13 @@ public class MappingRegistry implements MappingRule {
      *
      * @param inModel  in model
      * @param outModel out model
+     * @return context
      */
-    public void validateAndExecute(FieldModel inModel, FieldModel outModel) {
+    public Context validateAndExecute(FieldModel inModel, FieldModel outModel) {
         DefaultContext context = new DefaultContext(REGISTRY_METADATA);
         mappingRules.stream().filter(m -> m.validate(inModel, outModel))
                 .forEach(m -> m.executeOn(inModel, outModel, context));
+        return context;
     }
 
     /**
@@ -63,10 +63,13 @@ public class MappingRegistry implements MappingRule {
      * @param inModel  in model
      * @param outModel out model
      * @param context context
+     * @param <C> context type
+     * @return context
      */
-    public void validateAndExecute(FieldModel inModel, FieldModel outModel, Context context) {
+    public <C extends Context> C validateAndExecute(FieldModel inModel, FieldModel outModel, C context) {
         mappingRules.stream().filter(m -> m.validate(inModel, outModel))
                 .forEach(m -> m.executeOn(inModel, outModel, context));
+        return context;
     }
 
     /**
@@ -82,13 +85,14 @@ public class MappingRegistry implements MappingRule {
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+    public <C extends Context> C executeOn(FieldModel inModel, FieldModel outModel, C context) {
         mappingRules.forEach(rule -> rule.executeOn(inModel, outModel, context));
+        return context;
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel) {
-        this.executeOn(inModel, outModel, new DefaultContext(REGISTRY_METADATA));
+    public Context executeOn(FieldModel inModel, FieldModel outModel) {
+        return this.executeOn(inModel, outModel, new DefaultContext(REGISTRY_METADATA));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/NaryMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/NaryMappingRule.java
@@ -8,6 +8,8 @@ import java.util.Locale;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.impl.DefaultContext;
+import io.doov.core.dsl.impl.ModelInterceptor;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.MappingMetadata;
 import io.doov.core.dsl.meta.MetadataVisitor;
@@ -39,10 +41,15 @@ public class NaryMappingRule<O> implements MappingRule {
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel) {
-        outModel.set(outFieldInfo.id(),
-                typeConverter.convert(inModel, fieldInfos.toArray(new DslField[0])));
+    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+        ModelInterceptor in = new ModelInterceptor(inModel, context);
+        ModelInterceptor out = new ModelInterceptor(outModel, context);
+        out.set(outFieldInfo.id(), typeConverter.convert(in, context, fieldInfos.toArray(new DslField[0])));
+    }
 
+    @Override
+    public void executeOn(FieldModel inModel, FieldModel outModel) {
+        this.executeOn(inModel, outModel, new DefaultContext(metadata));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/NaryMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/NaryMappingRule.java
@@ -41,15 +41,16 @@ public class NaryMappingRule<O> implements MappingRule {
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+    public <C extends Context> C executeOn(FieldModel inModel, FieldModel outModel, C context) {
         ModelInterceptor in = new ModelInterceptor(inModel, context);
         ModelInterceptor out = new ModelInterceptor(outModel, context);
         out.set(outFieldInfo.id(), typeConverter.convert(in, context, fieldInfos.toArray(new DslField[0])));
+        return context;
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel) {
-        this.executeOn(inModel, outModel, new DefaultContext(metadata));
+    public Context executeOn(FieldModel inModel, FieldModel outModel) {
+        return this.executeOn(inModel, outModel, new DefaultContext(metadata));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/SimpleMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/SimpleMappingRule.java
@@ -10,8 +10,7 @@ import io.doov.core.dsl.DslField;
 import io.doov.core.dsl.impl.DefaultContext;
 import io.doov.core.dsl.impl.ModelInterceptor;
 import io.doov.core.dsl.lang.*;
-import io.doov.core.dsl.meta.MappingMetadata;
-import io.doov.core.dsl.meta.MetadataVisitor;
+import io.doov.core.dsl.meta.*;
 
 /**
  * 1-to-1 mapping rule
@@ -51,15 +50,16 @@ public class SimpleMappingRule<I, O> implements MappingRule {
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+    public <C extends Context> C executeOn(FieldModel inModel, FieldModel outModel, C context) {
         ModelInterceptor in = new ModelInterceptor(inModel, context);
         ModelInterceptor out = new ModelInterceptor(outModel, context);
         out.set(outFieldInfo.id(), typeConverter.convert(in, context, inFieldInfo));
+        return context;
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel) {
-        this.executeOn(inModel, outModel, new DefaultContext(metadata));
+    public Context executeOn(FieldModel inModel, FieldModel outModel) {
+        return this.executeOn(inModel, outModel, new DefaultContext(metadata));
     }
 
 }

--- a/core/src/main/java/io/doov/core/dsl/mapping/SimpleMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/SimpleMappingRule.java
@@ -7,8 +7,9 @@ import java.util.Locale;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
-import io.doov.core.dsl.lang.MappingRule;
-import io.doov.core.dsl.lang.TypeConverter;
+import io.doov.core.dsl.impl.DefaultContext;
+import io.doov.core.dsl.impl.ModelInterceptor;
+import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.MappingMetadata;
 import io.doov.core.dsl.meta.MetadataVisitor;
 
@@ -50,8 +51,15 @@ public class SimpleMappingRule<I, O> implements MappingRule {
     }
 
     @Override
+    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+        ModelInterceptor in = new ModelInterceptor(inModel, context);
+        ModelInterceptor out = new ModelInterceptor(outModel, context);
+        out.set(outFieldInfo.id(), typeConverter.convert(in, context, inFieldInfo));
+    }
+
+    @Override
     public void executeOn(FieldModel inModel, FieldModel outModel) {
-        outModel.set(outFieldInfo.id(), typeConverter.convert(inModel, inFieldInfo));
+        this.executeOn(inModel, outModel, new DefaultContext(metadata));
     }
 
 }

--- a/core/src/main/java/io/doov/core/dsl/mapping/StaticMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/StaticMappingRule.java
@@ -11,8 +11,9 @@ import java.util.function.Supplier;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
-import io.doov.core.dsl.lang.MappingRule;
-import io.doov.core.dsl.lang.StaticTypeConverter;
+import io.doov.core.dsl.impl.DefaultContext;
+import io.doov.core.dsl.impl.ModelInterceptor;
+import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.MappingMetadata;
 import io.doov.core.dsl.meta.MetadataVisitor;
 
@@ -36,8 +37,14 @@ public class StaticMappingRule<I, O> implements MappingRule {
     }
 
     @Override
+    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+        ModelInterceptor out = new ModelInterceptor(outModel, context);
+        out.set(outFieldInfo.id(), typeConverter.convert(context, inputObject.get()));
+    }
+
+    @Override
     public void executeOn(FieldModel inModel, FieldModel outModel) {
-        outModel.set(outFieldInfo.id(), typeConverter.convert(inputObject.get()));
+        this.executeOn(inModel, outModel, new DefaultContext(metadata));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/StaticMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/StaticMappingRule.java
@@ -37,14 +37,15 @@ public class StaticMappingRule<I, O> implements MappingRule {
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel, Context context) {
+    public <C extends Context> C executeOn(FieldModel inModel, FieldModel outModel, C context) {
         ModelInterceptor out = new ModelInterceptor(outModel, context);
         out.set(outFieldInfo.id(), typeConverter.convert(context, inputObject.get()));
+        return context;
     }
 
     @Override
-    public void executeOn(FieldModel inModel, FieldModel outModel) {
-        this.executeOn(inModel, outModel, new DefaultContext(metadata));
+    public Context executeOn(FieldModel inModel, FieldModel outModel) {
+        return this.executeOn(inModel, outModel, new DefaultContext(metadata));
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/mapping/TypeContextConverters.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/TypeContextConverters.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) by Courtanet, All Rights Reserved.
+ */
+package io.doov.core.dsl.mapping;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
+import io.doov.core.dsl.lang.*;
+
+public class TypeContextConverters {
+
+    // Simple Converters
+
+    public static <I, O> TypeConverter<I, O> converter(BiFunction<Context, Optional<I>, O> converter,
+            String description) {
+        return new DefaultTypeConverter<>(converter, description);
+    }
+
+    // ValueConverters
+
+    public static <I, O> StaticTypeConverter<I, O> valueConverter(BiFunction<Context, I, O> function,
+            String description) {
+        return new DefaultStaticTypeConverter<>(function, description);
+    }
+
+    // BiConverters
+
+    public static <I, J, O> BiTypeConverter<I, J, O> biConverter(
+            TriFunction<Context, Optional<I>, Optional<J>, O> converter, String description) {
+        return new DefaultBiTypeConverter<>(converter, description);
+    }
+
+    // NaryConverters
+
+    public static <O> NaryTypeConverter<O> nConverter(TriFunction<DslModel, Context, List<DslField>, O> function,
+            String description) {
+        return new DefaultNaryTypeConverter<>(function, description);
+    }
+
+}

--- a/core/src/main/java/io/doov/core/dsl/mapping/TypeConverters.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/TypeConverters.java
@@ -13,39 +13,52 @@ import io.doov.core.dsl.lang.*;
 
 public class TypeConverters {
 
-    public static <I, O> TypeConverter<I, O> converter(Function<I, O> converter, String description) {
+    // Simple Converters
+
+    public static <I, O> TypeConverter<I, O> converter(Function<I, O> converter,
+            String description) {
         return new DefaultTypeConverter<>(i -> i.map(converter).orElseGet(() -> converter.apply(null)), description);
     }
 
-    public static <I, O> TypeConverter<I, O> converter(Function<I, O> converter, O nullCase, String description) {
+    public static <I, O> TypeConverter<I, O> converter(Function<I, O> converter, O nullCase,
+            String description) {
         return new DefaultTypeConverter<>(i -> i.map(converter).orElse(nullCase), description);
     }
 
-    public static <I, O> StaticTypeConverter<I, O> valueConverter(Function<I, O> function, String description) {
-        return new DefaultStaticTypeConverter<>((context, i) -> function.apply(i), description);
+    // ValueConverters
+
+    public static <I, O> StaticTypeConverter<I, O> valueConverter(Function<I, O> function,
+            String description) {
+        return new DefaultStaticTypeConverter<>(function, description);
     }
+
+    // BiConverters
 
     public static <I, J, O> BiTypeConverter<I, J, O> biConverter(BiFunction<Optional<I>, Optional<J>, O> converter,
             String description) {
         return new DefaultBiTypeConverter<>(converter, description);
     }
 
-    public static <I, J, O> BiTypeConverter<I, J, O> biConverter(BiFunction<I, J, O> converter,
-            O nullCase, String description) {
-        return new DefaultBiTypeConverter<>(
-                (i, j) -> (i.isPresent() && j.isPresent()) ? converter.apply(i.get(), j.get()) : nullCase, description);
+    public static <I, J, O> BiTypeConverter<I, J, O> biConverter(BiFunction<I, J, O> converter, O nullCase,
+            String description) {
+        return new DefaultBiTypeConverter<>((i, j) -> (i.isPresent() && j.isPresent()) ?
+                converter.apply(i.get(), j.get()) : nullCase, description);
     }
 
-    public static <I, J, O> BiTypeConverter<I, J, O> biConverter(BiFunction<I, J, O> converter,
-            I nullIn, J nullIn2, String description) {
+    public static <I, J, O> BiTypeConverter<I, J, O> biConverter(BiFunction<I, J, O> converter, I nullIn, J nullIn2,
+            String description) {
         return new DefaultBiTypeConverter<>((i, j) -> converter.apply(i.orElse(nullIn), j.orElse(nullIn2)),
                 description);
     }
+
+    // NaryConverters
 
     public static <O> NaryTypeConverter<O> nConverter(BiFunction<DslModel, List<DslField>, O> function,
             String description) {
         return new DefaultNaryTypeConverter<>(function, description);
     }
+
+    // Utility converters
 
     public static NaryTypeConverter<Integer> counter(String description) {
         return nConverter((model, fieldInfos) ->

--- a/core/src/main/java/io/doov/core/dsl/mapping/TypeConverters.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/TypeConverters.java
@@ -7,8 +7,8 @@ import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.lang.*;
 
 public class TypeConverters {
@@ -22,7 +22,7 @@ public class TypeConverters {
     }
 
     public static <I, O> StaticTypeConverter<I, O> valueConverter(Function<I, O> function, String description) {
-        return new DefaultStaticTypeConverter<>(function, description);
+        return new DefaultStaticTypeConverter<>((context, i) -> function.apply(i), description);
     }
 
     public static <I, J, O> BiTypeConverter<I, J, O> biConverter(BiFunction<Optional<I>, Optional<J>, O> converter,
@@ -42,7 +42,7 @@ public class TypeConverters {
                 description);
     }
 
-    public static <O> NaryTypeConverter<O> nConverter(BiFunction<FieldModel, List<DslField>, O> function,
+    public static <O> NaryTypeConverter<O> nConverter(BiFunction<DslModel, List<DslField>, O> function,
             String description) {
         return new DefaultNaryTypeConverter<>(function, description);
     }

--- a/core/src/main/java/io/doov/core/dsl/meta/MappingMetadata.java
+++ b/core/src/main/java/io/doov/core/dsl/meta/MappingMetadata.java
@@ -5,6 +5,7 @@ package io.doov.core.dsl.meta;
 
 import static io.doov.core.dsl.meta.ElementType.FIELD;
 import static io.doov.core.dsl.meta.ElementType.OPERATOR;
+import static io.doov.core.dsl.meta.ElementType.UNKNOWN;
 import static io.doov.core.dsl.meta.MappingOperator.map;
 import static io.doov.core.dsl.meta.MappingOperator.to;
 import static io.doov.core.dsl.meta.ast.AstVisitorUtils.astToString;
@@ -16,10 +17,11 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.Supplier;
+import java.util.function.*;
 import java.util.stream.Stream;
 
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.lang.Context;
 
 public class MappingMetadata implements Metadata {
@@ -65,6 +67,14 @@ public class MappingMetadata implements Metadata {
                 .field(outField);
     }
 
+    public static MappingMetadata mapping(BiFunction<DslModel, Context, ?> supplier, DslField outField) {
+        return new MappingMetadata(MetadataType.SINGLE_MAPPING)
+                .operator(map)
+                .function()
+                .operator(to)
+                .field(outField);
+    }
+
     private MappingMetadata fields(List<DslField> fields) {
         Iterator<DslField> iterator = fields.iterator();
         iterator.forEachRemaining(f -> {
@@ -82,6 +92,10 @@ public class MappingMetadata implements Metadata {
 
     private MappingMetadata value(Supplier<?> supplier) {
         return add(new Element(() -> String.valueOf(supplier.get()), ElementType.VALUE));
+    }
+
+    private MappingMetadata function() {
+        return add(new Element(() -> "-function-", UNKNOWN));
     }
 
     private MappingMetadata field(DslField readable) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -50,6 +50,7 @@ subprojects {
 
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
+        options.compilerArgs << '-proc:none'
     }
 
     test {


### PR DESCRIPTION
Context propagation for mapping rules.
Ability to pass custom Context implementations to Validation and Mapping Rules.
* Fix missing javadoc annotations
* Context-aware mapping
* Fix on type converter implementation